### PR TITLE
Feature/accessibility fix

### DIFF
--- a/inc/tna-form-builder.php
+++ b/inc/tna-form-builder.php
@@ -112,7 +112,7 @@ if ( !class_exists( 'Newsletter_Form_Builder' ) ) {
          */
         public function get_email_input(){
             if(function_exists('esc_attr')) {
-                $email ='<div class="form-row"><label for="email">%s</label><input type="email" name="email" id="email" placeholder="Enter your email address" aria-labelledby="newsletterAccessibility" required></div>';
+                $email ='<div class="form-row"><label for="email">%s</label><input type="email" name="email" id="email" placeholder="Enter your email address" required></div>';
                 
                 return sprintf($email,esc_attr('Email address'));
             } 
@@ -124,7 +124,7 @@ if ( !class_exists( 'Newsletter_Form_Builder' ) ) {
          */
         public function get_first_name_input(){
             if(function_exists('esc_attr')) {
-                $fname ='<div class="form-row"><label for="firstname">%s <span class="optional">%s</span></label><input type="text" name="firstname" id="firstname" placeholder="Enter your first name" aria-labelledby="newsletterAccessibility"></div>';
+                $fname ='<div class="form-row"><label for="firstname">%s <span class="optional">%s</span></label><input type="text" name="firstname" id="firstname" placeholder="Enter your first name"></div>';
 
                 return sprintf($fname,esc_attr('First name'),esc_attr('(optional)'));
             }  
@@ -136,7 +136,7 @@ if ( !class_exists( 'Newsletter_Form_Builder' ) ) {
          */
         public function get_last_name_input(){
             if(function_exists('esc_attr')) {
-                $lname = '<div class="form-row"><label for="lastname">%s <span class="optional">%s</span></label><input type="text" name="lastname" id="lastname" placeholder="Enter your last name" aria-labelledby="newsletterAccessibility"></div>';
+                $lname = '<div class="form-row"><label for="lastname">%s <span class="optional">%s</span></label><input type="text" name="lastname" id="lastname" placeholder="Enter your last name"></div>';
 
                 return sprintf($lname,esc_attr('Last name'),esc_attr('(optional)'));
             }

--- a/tests/tnaNewsletterTest.php
+++ b/tests/tnaNewsletterTest.php
@@ -58,17 +58,17 @@ class tnaNewsletterTest extends PHPUnit_Framework_TestCase
 
         // @method->get_email_input()
         $this->assertTrue(method_exists($form, 'get_email_input'));
-        $this->assertEquals('<div class="form-row"><label for="email">Email address</label><input type="email" name="email" id="email" placeholder="Enter your email address" aria-labelledby="newsletterAccessibility" required></div>', $form->get_email_input());
+        $this->assertEquals('<div class="form-row"><label for="email">Email address</label><input type="email" name="email" id="email" placeholder="Enter your email address" required></div>', $form->get_email_input());
         $this->assertNotEquals(null,$form->get_email_input());
 
         // $method->get_first_name_input()
         $this->assertTrue(method_exists($form, 'get_first_name_input'));
-        $this->assertEquals('<div class="form-row"><label for="firstname">First name <span class="optional">(optional)</span></label><input type="text" name="firstname" id="firstname" placeholder="Enter your first name" aria-labelledby="newsletterAccessibility"></div>', $form->get_first_name_input());
+        $this->assertEquals('<div class="form-row"><label for="firstname">First name <span class="optional">(optional)</span></label><input type="text" name="firstname" id="firstname" placeholder="Enter your first name"></div>', $form->get_first_name_input());
         $this->assertNotEquals(null,$form->get_first_name_input());
 
         // @method->get_last_name_input()
         $this->assertTrue(method_exists($form, 'get_last_name_input'));
-        $this->assertEquals('<div class="form-row"><label for="lastname">Last name <span class="optional">(optional)</span></label><input type="text" name="lastname" id="lastname" placeholder="Enter your last name" aria-labelledby="newsletterAccessibility"></div>', $form->get_last_name_input());
+        $this->assertEquals('<div class="form-row"><label for="lastname">Last name <span class="optional">(optional)</span></label><input type="text" name="lastname" id="lastname" placeholder="Enter your last name"></div>', $form->get_last_name_input());
         $this->assertNotEquals(null,$form->get_last_name_input());
 
         // @method->get_terms_checkbox()


### PR DESCRIPTION
Hi @JamesWChan 

Would you be able to merge this branch?

It simply removes an `aria-labelledby` attribute which was on the form inputs. They are not needed according to the WAVE Chrome extension.

Thanks :+1: